### PR TITLE
generate multiple ratios' sprite once

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Usage: sprite-one [options] <sprite_filename> <icons_directory>
 generate sprite from icons
 
 Options:
-  -v, --version        output the version number
-  -r, --ratio <ratio>  pixel ratio to generate sprite. default is 1.
-  -h, --help           display help for command
+  -v, --version            output the version number
+  -r, --ratio <ratios...>  pixel ratio to generate sprite. default is 1.
+  -h, --help               display help for command
 ```
 
 - npm
@@ -33,8 +33,10 @@ Options:
 ```javascript
 import { generateSprite } from '@smellman/sprite-one'
 
-generateSprite('../out', '../input', 2).then(() => {})
+generateSprite('../out', '../input', [2]).then(() => {})
 ```
+
+If multiple ratios are specified in either CLI or Nodejs, the default file names when the ratio is more than one will be changed to the standard file name used by mapbox and maplibre (e.g., `sprite.json` for 1 ratio, `sprite@2x.json` for 2 ratio...).
 
 ## Develop
 

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -11,13 +11,15 @@ program
   .arguments('<icons_directory>')
   .description('generate sprite from icons')
   .option(
-    '-r, --ratio <ratio>',
+    '-r, --ratio <ratios...>',
     'pixel ratio to generate sprite. default is 1.'
   )
   .action(async (spriteFilename: string, iconsDirectory: string) => {
     const options = program.opts()
     if (options.ratio) {
-      options.ratio = Number(options.ratio)
+      options.ratio = options.ratio.map((r: string) => {
+        return Number(r)
+      })
     }
     await generateSprite(spriteFilename, iconsDirectory, options.ratio)
   })

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -5,13 +5,20 @@ import { Matrix } from './matrix'
 import sharp from 'sharp'
 import { SpriteImage } from './interfaces'
 
-export const generateSprite = async (
+const generate = async (
   output_file_name: string,
   input_directory: string,
-  ratio = 1
-): Promise<void> => {
-  const output_json = `${output_file_name}.json`
-  const output_png = `${output_file_name}.png`
+  ratio: number,
+  defaultSpriteName = false
+) => {
+  let spriteName = ''
+  if (defaultSpriteName === true) {
+    if (ratio > 1) {
+      spriteName = `@${ratio}x`
+    }
+  }
+  const output_json = `${output_file_name}${spriteName}.json`
+  const output_png = `${output_file_name}${spriteName}.png`
   // Get file list
   const images: Image[] = []
   const files = fs.readdirSync(input_directory)
@@ -50,4 +57,18 @@ export const generateSprite = async (
       fs.writeFileSync(output_json, JSON.stringify(json))
     }
   )
+}
+
+export const generateSprite = async (
+  output_file_name: string,
+  input_directory: string,
+  ratios: number[] = [1]
+): Promise<void> => {
+  const promises: Promise<void>[] = []
+  ratios.forEach((ratio) => {
+    promises.push(
+      generate(output_file_name, input_directory, ratio, ratios.length > 1)
+    )
+  })
+  await Promise.all(promises)
 }

--- a/tests/lib/index.test.ts
+++ b/tests/lib/index.test.ts
@@ -3,7 +3,7 @@ import os from 'os'
 import path from 'path'
 
 import { generateSprite } from '../../src/lib/index'
-import { SpriteImage } from '../../src/lib/interfaces'
+import { checkRatioInSpriteJson } from '../util'
 
 describe('test lib/index.ts', (): void => {
   let tmpDir = ''
@@ -21,33 +21,39 @@ describe('test lib/index.ts', (): void => {
 
   test('sprite (json and png) must exist after generating', async () => {
     const output_file_name = path.join(tmpDir, './test1')
-    const pixelRatio = 1
-    await generateSprite(output_file_name, iconsDir, pixelRatio)
+    const pixelRatios = [1]
+    await generateSprite(output_file_name, iconsDir, pixelRatios)
     expect(fs.existsSync(`${output_file_name}.json`)).toBeTruthy()
     expect(fs.existsSync(`${output_file_name}.png`)).toBeTruthy()
 
-    const spriteJSON: {
-      [key: string]: SpriteImage
-    } = await require(`${output_file_name}.json`)
-    Object.keys(spriteJSON).forEach((key) => {
-      const json = spriteJSON[key]
-      expect(json.pixelRatio).toBe(pixelRatio)
-    })
+    await checkRatioInSpriteJson(`${output_file_name}.json`, pixelRatios[0])
   })
 
   test('sprite must exist with pixelRatio = 2', async () => {
     const output_file_name = path.join(tmpDir, './test2')
-    const pixelRatio = 2
-    await generateSprite(output_file_name, iconsDir, pixelRatio)
+    const pixelRatios = [2]
+    await generateSprite(output_file_name, iconsDir, pixelRatios)
     expect(fs.existsSync(`${output_file_name}.json`)).toBeTruthy()
     expect(fs.existsSync(`${output_file_name}.png`)).toBeTruthy()
 
-    const spriteJSON: {
-      [key: string]: SpriteImage
-    } = await require(`${output_file_name}.json`)
-    Object.keys(spriteJSON).forEach((key) => {
-      const json = spriteJSON[key]
-      expect(json.pixelRatio).toBe(pixelRatio)
-    })
+    await checkRatioInSpriteJson(`${output_file_name}.json`, pixelRatios[0])
+  })
+
+  test('multiple sprites with different ratio should be generated', async () => {
+    const output_file_name = path.join(tmpDir, './test3')
+    const pixelRatios = [1, 2]
+    await generateSprite(output_file_name, iconsDir, pixelRatios)
+    expect(fs.existsSync(`${output_file_name}.json`)).toBeTruthy()
+    expect(fs.existsSync(`${output_file_name}.png`)).toBeTruthy()
+    expect(fs.existsSync(`${output_file_name}@2x.json`)).toBeTruthy()
+    expect(fs.existsSync(`${output_file_name}@2x.png`)).toBeTruthy()
+
+    for (let i = 0; i < pixelRatios.length; i++) {
+      const ratio = pixelRatios[i]
+      await checkRatioInSpriteJson(
+        `${output_file_name}${ratio > 1 ? `@${ratio}x` : ''}.json`,
+        ratio
+      )
+    }
   })
 })

--- a/tests/util/checkRatioInSpriteJson.ts
+++ b/tests/util/checkRatioInSpriteJson.ts
@@ -1,0 +1,11 @@
+import { SpriteImage } from '../../src/lib/interfaces'
+
+export const checkRatioInSpriteJson = async (output: string, ratio: number) => {
+  const spriteJSON: {
+    [key: string]: SpriteImage
+  } = await require(output)
+  Object.keys(spriteJSON).forEach((key) => {
+    const json = spriteJSON[key]
+    expect(json.pixelRatio).toBe(ratio)
+  })
+}

--- a/tests/util/index.ts
+++ b/tests/util/index.ts
@@ -1,0 +1,1 @@
+export * from './checkRatioInSpriteJson'


### PR DESCRIPTION
fixed #5 

If multiple ratios are specified in either CLI or Nodejs, the default file names when the ratio is more than one will be changed to the standard file name used by mapbox and maplibre (e.g., `sprite.json` for 1 ratio, `sprite@2x.json` for 2 ratio...).
If only a ratio is specified, filename will be the same with output file name parameter even the ratio is more than one.