### PR TITLE
add release.yml for auto generate release note

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - Semver-Minor
+        - enhancement
+    - title: Other Changes
+      labels:
+        - '*'


### PR DESCRIPTION
To support [Auto generate release note](https://docs.github.com/ja/repositories/releasing-projects-on-github/automatically-generated-release-notes)