### PR TITLE
Fix icon name processing with relative paths

### DIFF
--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import sharp from 'sharp'
 import { SpriteImage } from './interfaces'
 
@@ -14,7 +15,7 @@ export class Image {
   y = 0
   constructor(svg_file: string, ratio: number, name?: string) {
     this.svg_file = svg_file
-    this.name = typeof name !== 'undefined' ? name : svg_file.match(/([^/]*)\./)![1]
+    this.name = typeof name !== 'undefined' ? name : path.basename(svg_file).match(/([^/]*)\./)![1]
     this.ratio = ratio
   }
 

--- a/tests/lib/image.test.ts
+++ b/tests/lib/image.test.ts
@@ -1,0 +1,18 @@
+import path from 'node:path'
+import { Image } from '../../src/lib/image'
+
+describe('test lib/image.ts', (): void => {
+  const iconsDir = path.join(__dirname, '../icons')
+
+  it('works', async () => {
+    const image = new Image(path.join(iconsDir, 'airport.svg'), 1)
+    await image.parse()
+    expect(image.real_height()).toStrictEqual(15)
+    expect(image.real_width()).toStrictEqual(15)
+  })
+
+  it('correctly parses relative paths', () => {
+    const image = new Image('../test_image.svg', 1)
+    expect(image.name).toStrictEqual('test_image')
+  })
+})


### PR DESCRIPTION
Previously, when the icon name was a relative path like `../something`, the Image.name property was set to `.`. This fixes that problem by using `path.basename` to extract the last part of the path first, then running the regular expression to remove the extension from the filename.

I've included a test case as well