### PR TITLE
#25 remove test codes from npm packages, bump 0.1.2 release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,4 @@
 .vscode/
 *.tgz
+.github/
+tests/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@unvt/sprite-one",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@unvt/sprite-one",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "bin-pack": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unvt/sprite-one",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Generate sprite images and json without mapnik",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
- #25 remove test codes from npm package.
  - npm package will be `unpacked size: 16.7 kB`.
- version up to 0.1.2