### PR TITLE
fix SDF generation for scaled sprites

### DIFF
--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -25,6 +25,7 @@ export class Image {
     this.name = name
     this.ratio = ratio
     this.file_ratio = file_ratio || 1
+    this.buffer_length *= this.ratio
 
     if (this.file_ratio > 1 && this.ratio !== this.file_ratio) {
       throw new Error(
@@ -73,7 +74,7 @@ export class Image {
         ])
         .raw()
         .toBuffer()
-      const radius = 8
+      const radius = 8 * this.ratio
       const img = this.rendered_image
       const pixelArray = new Uint8ClampedArray(img!.buffer)
       const alphas = []


### PR DESCRIPTION
I recently discovered that sprite-one isn't correctly generating scaled SDF sprites. Namely, the radius within which the signed distance from the sprite is computed should be scaled too.

See these screenshots, `dschep_sprite-one` is the sprite generated with this change, the other two are those generated by [spreet](https://github.com/flother/spreet) and sprite-one.

1x sheet. everything looks good:
![image](https://github.com/user-attachments/assets/153f1662-0577-437d-a6ea-9a692a652cf2)

2x sheet. sprite-one and spreet look wrong but the change from this PR looks correct:
![image](https://github.com/user-attachments/assets/a593836e-9c72-432a-94bf-56722e3c7ae9)


My repo containing a demo reproducing this issue is: https://github.com/dschep-bug-repos/sdf-2x-generation/