### PR TITLE
remove tests code from npm build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "bin": {
     "sprite-one": "dist/bin/index.js"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "test": "jest",


### PR DESCRIPTION
## Summary
- `package.json` に `files` フィールドを追加し、`dist` ディレクトリのみをnpmパッケージに含めるように変更
- テストコードやソースコードがnpmパッケージから除外され、パッケージサイズが削減される

closes #25

## Test plan
- [x] `npm pack --dry-run` でパッケージに含まれるファイルを確認し、テストコードが除外されていることを検証
- [x] `npm publish --dry-run` で公開前の確認