### PR TITLE
move to OIDC for npm publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
-        run: npm install
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: npm ci
       - name: build
         run: npm run build
       - name: test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@unvt'
+      - run: npm install -g npm@11.5.1
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Test
+        run: npm test
+      - name: Publish
+        run: npm publish --provenance --access public

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unvt/sprite-one.git"
+  },
   "engines": {
     "node": ">=22.0.0"
   }


### PR DESCRIPTION
## Summary
- `v*` タグのpush時にnpmへ公開する `publish.yml` ワークフローを追加（OIDC provenance対応）
- `package.json` に `repository` フィールドを追加（provenance生成に必要）
- `build.yml` の `npm install` を `npm ci` に変更し、不要な `NODE_AUTH_TOKEN` を削除

closes #35

## Test plan
- [x] npmjs.orgでパッケージのpublishing accessをGitHub Actionsに許可
- [ ] `v*` タグをpushしてワークフローが正常に動作することを確認